### PR TITLE
feat(chat): add real-time message read notification

### DIFF
--- a/src/controller/chat.controller.ts
+++ b/src/controller/chat.controller.ts
@@ -50,7 +50,6 @@ export class ChatController {
     const receiverId=req.params.id;
     try{
       const readCounts = await chatService.getUnreadCounts(userId as string,receiverId)
-      console.log("🚀 ~ ChatController ~ getUnreadCounts ~ readCounts:", readCounts)
       res.status(StatusCodes.SUCCESS).json({
         status:true,
         data:readCounts

--- a/src/controller/comment.controller.ts
+++ b/src/controller/comment.controller.ts
@@ -5,20 +5,7 @@ import {Message} from '../constant/messages'
 import commentService from "../services/comment.service";
 import { CommentDTO } from "../dto/comment.dto";
 export class CommentController {
-    // try {
-    //     const data=await notesService.create(userId, notesDTO)
-    //     console.log(data,'dataa')
-    //     res.status(StatusCodes.CREATED).json({
-    //       status: true,
-    //       message: Message.created,
-    //       data,
-    //     })
-    //   } catch (error: any) {
-    //     res.status(error.status || StatusCodes.INTERNAL_SERVER_ERROR).json({
-    //       status: false,
-    //       message: error.message,
-    //     })
-    //   }
+ 
     async addComment(req:Request,res:Response)
     {
         try{
@@ -45,7 +32,6 @@ export class CommentController {
         try{
              
             const commentId= req.params.id
-            console.log(commentId,"comment id")
             const data = await commentService.update(commentId as string,req.body as CommentDTO)
             res.status(StatusCodes.CREATED).json({
                 status:true,

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -59,7 +59,6 @@ class ChatService {
       const decryptedChats = chats.map(chat => {
         try {
           const decryptedMessage = EncryptionService.decryptMessage(chat.content);
-          console.log("Decrypted message:", decryptedMessage);
           return { ...chat, content: decryptedMessage };
         } catch (error) {
           console.error(`Failed to decrypt message with ID ${chat.id}:`, error);
@@ -74,12 +73,23 @@ class ChatService {
     }
   }
 
+  // async readMessages(receiverId:string,senderId:string){
+  //   const messages = await this.messageRepo.update({
+  //     sender:{id:senderId},
+  //     receiver:{id:receiverId},
+  //     read:false
+  //   },
+  //  {read:true} 
+  // )
+  // return messages
+  // }
+
   async readMessages(receiverId:string,senderId:string) {
     const messages = await this.messageRepo.findBy({sender_id:senderId,receiver_id:receiverId  });
     messages.forEach(message => {
       message.read = true;
     });
-    const result = await this.messageRepo.save(messages);
+    return await this.messageRepo.save(messages);
   }
   async getUnreadCounts(senderId: string, receiverId: string) {
     const unreadCount = await this.messageRepo.count({
@@ -89,7 +99,6 @@ class ChatService {
         read: false,
       }
     });
-    
     return unreadCount;
   }
 

--- a/src/socket/chatSocket.ts
+++ b/src/socket/chatSocket.ts
@@ -1,109 +1,106 @@
-import { Server } from 'socket.io'
-import chatService from '../services/chat.service'
-import HttpException from '../utils/HttpException.utils'
-import { Message } from '../constant/messages'
-import { DotenvConfig } from '../config/env.config'
-import webTokenService from '../utils/webToken.service'
-import RoomService from '../services/room.service'
-import userService from '../services/user.service'
-import friendService from '../services/friend.service'
-import { get } from 'http'
+import {Server} from 'socket.io';
+import chatService from '../services/chat.service';
+import HttpException from '../utils/HttpException.utils';
+import {Message} from '../constant/messages';
+import {DotenvConfig} from '../config/env.config';
+import webTokenService from '../utils/webToken.service';
+import RoomService from '../services/room.service';
+import userService from '../services/user.service';
+import friendService from '../services/friend.service';
+import {get} from 'http';
 
 export class ChatSocket {
-  private userSockets = new Map() // Map to track user ID to socket ID
+  private userSockets = new Map(); // Map to track user ID to socket ID
   async setupSocket(server: any) {
     const io = new Server(server, {
       cors: {
         origin: '*',
       },
-    })
+    });
     io.use((socket, next) => {
-      const token = socket.handshake.auth.token
+      const token = socket.handshake.auth.token;
       if (!token) {
-        return next(HttpException.unauthorized(Message.notAuthorized))
+        return next(HttpException.unauthorized(Message.notAuthorized));
       }
       try {
-        const payload = webTokenService.verify(token, DotenvConfig.ACCESS_TOKEN_SECRET)
+        const payload = webTokenService.verify(token, DotenvConfig.ACCESS_TOKEN_SECRET);
         if (payload) {
-          socket.data.user = payload
-          next()
+          socket.data.user = payload;
+          next();
         } else {
-          return next(HttpException.unauthorized(Message.notAuthorized))
+          return next(HttpException.unauthorized(Message.notAuthorized));
         }
       } catch (err: any) {
         if (err.name === 'TokenExpiredError') {
-          return next(HttpException.unauthorized(Message.tokenExpired))
+          return next(HttpException.unauthorized(Message.tokenExpired));
         } else {
-          return next(HttpException.unauthorized(Message.notAuthorized))
+          return next(HttpException.unauthorized(Message.notAuthorized));
         }
       }
-    })
+    });
 
     io.on('connection', async (socket) => {
-    
-      const userId = socket.data.user.id
-      this.userSockets.set(userId, socket.id)
+      const userId = socket.data.user.id;
+      this.userSockets.set(userId, socket.id);
       // Mark user as active when they connect
       try {
-        await userService.active(userId)
-        io.emit('statusChange', { userId, active: true }) // Notify all clients about the user's active status
+        await userService.active(userId);
+        io.emit('statusChange', {userId, active: true}); // Notify all clients about the user's active status
       } catch (error) {
-        console.error('Error marking user as active:', error)
+        console.error('Error marking user as active:', error);
       }
       // Handle joining rooms
-      socket.on('joinRoom', async ({ receiverId }) => {
-        const roomService = new RoomService()
-        const room = await roomService.findOrCreateIfNotExist([userId, receiverId])
-        console.log("🚀 ~ ChatSocket ~ socket.on ~ room:", room)
+      socket.on('joinRoom', async ({receiverId}) => {
+        const roomService = new RoomService();
+        const room = await roomService.findOrCreateIfNotExist([userId, receiverId]);
+        console.log('🚀 ~ ChatSocket ~ socket.on ~ room:', room);
         if (room) {
           // Leave any other room the user might have joined previously
-          const currentRooms = Array.from(socket.rooms)
+          const currentRooms = Array.from(socket.rooms);
           currentRooms.forEach((roomId) => {
             if (roomId !== socket.id) {
               // socket.id is the default room, don't leave it
-              socket.leave(roomId)
+              socket.leave(roomId);
             }
-          })
-          socket.join(room.id)
-          
+          });
+          socket.join(room.id);
         } else {
-          console.error('Room creation or retrieval failed')
+          console.error('Room creation or retrieval failed');
         }
-      })
+      });
       // Handle friend request and emit event to specific user
       socket.on('request', async (receiverId: string) => {
-        const sendFriendRequest = await friendService.addFriend(userId, receiverId)
-        const receiverDetails = await userService.getById(receiverId)
-        const senderDetails = await userService.getById(userId)
-        const notiService = await friendService.addNotification(userId, receiverId)
-        const receiverSocketId = this.userSockets.get(receiverId)
+        const sendFriendRequest = await friendService.addFriend(userId, receiverId);
+        const receiverDetails = await userService.getById(receiverId);
+        const senderDetails = await userService.getById(userId);
+        const notiService = await friendService.addNotification(userId, receiverId);
+        const receiverSocketId = this.userSockets.get(receiverId);
         if (receiverSocketId) {
-          io.to(receiverSocketId).emit('notiReceiver', { receiverId, senderDetails, notiService })
+          io.to(receiverSocketId).emit('notiReceiver', {receiverId, senderDetails, notiService});
         } else {
-          console.log('Receiver not connected')
+          console.log('Receiver not connected');
         }
-      })
-      socket.on('markAsRead',async(notificationId)=>{
-        const markRead=friendService.markNotification(notificationId)
-        
-      })
+      });
+      socket.on('markAsRead', async (notificationId) => {
+        const markRead = friendService.markNotification(notificationId);
+      });
       // Handle typing event
-      socket.on('typing', async ({ receiverId }) => {
-        const roomService = new RoomService()
-        const room = await roomService.findOrCreateIfNotExist([userId, receiverId])
+      socket.on('typing', async ({receiverId}) => {
+        const roomService = new RoomService();
+        const room = await roomService.findOrCreateIfNotExist([userId, receiverId]);
         if (room) {
-          io.to(room.id).emit('typing', { userId })
+          io.to(room.id).emit('typing', {userId});
         }
-      })
-      socket.on('sendMessage', async ({ receiverId, content }) => {
-        const roomService = new RoomService()
-        const room = await roomService.findOrCreateIfNotExist([userId, receiverId])
-       
+      });
+      socket.on('sendMessage', async ({receiverId, content}) => {
+        const roomService = new RoomService();
+        const room = await roomService.findOrCreateIfNotExist([userId, receiverId]);
+
         if (room) {
           try {
-            const message = await chatService.sendMessage(userId, receiverId, content, room.id)
-            const senderDetails = await userService.getById(userId)
-            const receiverDetails = await userService.getById(receiverId)
+            const message = await chatService.sendMessage(userId, receiverId, content, room.id);
+            const senderDetails = await userService.getById(userId);
+            const receiverDetails = await userService.getById(receiverId);
             // Attach sender and receiver details to the message
             const enrichedMessage = {
               ...message,
@@ -119,54 +116,62 @@ export class ChatSocket {
                   profileImage: receiverDetails.details.profileImage,
                 },
               },
-            }
-            io.to(room.id).emit('message', enrichedMessage)
-            console.log(`Message sent from ${userId} to ${receiverId}`)
+            };
+            io.to(room.id).emit('message', enrichedMessage);
+            console.log(`Message sent from ${userId} to ${receiverId}`);
           } catch (error) {
-            console.error('Error sending message:', error)
+            console.error('Error sending message:', error);
           }
         } else {
-          console.error('Room creation or retrieval failed')
+          console.error('Room creation or retrieval failed');
         }
-      })
-      socket.on('markMessagesAsRead', async ({ receiverId }) => {
+      });
+      socket.on('readed', async ({receiverId}) => {
         try {
-          const reads = await chatService.readMessages(userId,receiverId)
-          console.log("🚀 ~ ChatSocket ~ socket.on ~ reads:", reads)
-          // Emit the messagesRead event to notify the client that these messages are marked as read
-          // io.to(socket.id).emit('messagesRead', { messageIds })
+          const reads = await chatService.readMessages(userId, receiverId);
+          console.log("🚀zcshf ~ ChatSocket ~ socket.on ~ userId:", userId)
+          
+          const unreadCount = await chatService.getUnreadCounts(userId, receiverId);
+          console.log('🚀 ~ ChatSocket ~ socket.on ~ reads:', reads);
+
+          // io.to(userId).emit('read', {receiverId, unreadCount})
+          // if (userSocketID) {
+          //   io.to(userSocketID).emit('read', {receiverId, unreadCount});
+          // }
+          const receiverSocketId = this.userSockets.get(userId);
+          if (receiverSocketId) {
+            io.to(receiverSocketId).emit('read', {receiverId, unreadCount});
+          } else {
+            console.log('Receiver not connected');
+          }
         } catch (error) {
-          console.error('Error marking messages as read:', error)
+          console.error('Error marking messages as read:', error);
         }
-      })
-      socket.on('unreadCounts',async({receiverId})=>{
-        const unreadMessageCount = await chatService.getUnreadCounts(userId,receiverId)
-      })
-      socket.on('accepted', async ({ id, senderId }) => {
+      });
+      socket.on('accepted', async ({id, senderId}) => {
         try {
-          console.log(id, 'id ho la')
-          console.log(senderId, 'sender ko chai ID')
-          const receiverDetails = await userService.getById(senderId)
-          const senderDetails = await userService.getById(userId)
+          console.log(id, 'id ho la');
+          console.log(senderId, 'sender ko chai ID');
+          const receiverDetails = await userService.getById(senderId);
+          const senderDetails = await userService.getById(userId);
           // console.log(senderDetails,'sender Details')
           // console.log(receiverDetails,"receiver Details")
-
-          io.to(userId).emit('accept', { receiverDetails, senderDetails })
+          io.to(userId).emit('accept', {receiverDetails, senderDetails});
         } catch (error) {
-          console.log('error haha', error)
+          console.log('error haha', error);
         }
-      })
+      });
       // Handle disconnect
       socket.on('disconnect', async () => {
-        console.log(`User disconnected: ${socket.id}`)
+        console.log(`User disconnected: ${socket.id}`);
         try {
-          await userService.offline(userId) // Update user's status to offline
-          io.emit('statusChange', { userId, active: false }) // Notify all clients about the user's offline status
-          console.log(`User ${userId} marked as offline`)
+          await userService.offline(userId); // Update user's status to offline
+          io.emit('statusChange', {userId, active: false}); // Notify all clients about the user's offline status
+          console.log(`User ${userId} marked as offline`);
         } catch (error) {
-          console.error('Error marking user as offline:', error)
+          console.error('Error marking user as offline:', error);
         }
-      })
-    })
+      });
+    });
   }
 }


### PR DESCRIPTION
- Implemented real-time notifications for when a user marks messages as read.
- Added `messagesRead` socket event to notify clients when their messages have been read.
- Updated `useEffect` to handle the `messagesRead` event and reset the unread message count for the appropriate user.
- Ensured that the `messagesRead` event is emitted only to the intended recipient, preventing infinite request loops.